### PR TITLE
fix log level

### DIFF
--- a/custom_components/ha_comfoconnectpro/__init__.py
+++ b/custom_components/ha_comfoconnectpro/__init__.py
@@ -67,10 +67,7 @@ from .const import (
 import sys
 import logging
 
-thismodule = sys.modules[__name__]
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
-_LOGGER.info(f"{thismodule} loaded.")
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,  # BINARYSENSOR_TYPES (r/o)

--- a/custom_components/ha_comfoconnectpro/config_flow.py
+++ b/custom_components/ha_comfoconnectpro/config_flow.py
@@ -31,10 +31,7 @@ from .const import (
 import sys
 import logging
 
-thismodule = sys.modules[__name__]
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
-_LOGGER.info(f"{thismodule} loaded.")
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/custom_components/ha_comfoconnectpro/const.py
+++ b/custom_components/ha_comfoconnectpro/const.py
@@ -43,8 +43,6 @@ import logging
 
 thismodule = sys.modules[__name__]
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
-_LOGGER.info(f"{thismodule} loaded")
 
 
 DOMAIN = "ha_comfoconnectpro"

--- a/custom_components/ha_comfoconnectpro/entity_common.py
+++ b/custom_components/ha_comfoconnectpro/entity_common.py
@@ -16,10 +16,7 @@ import sys
 import logging
 from homeassistant.components.sensor import SensorDeviceClass
 
-thismodule = sys.modules[__name__]
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(logging.DEBUG)
-_LOGGER.info(f"{thismodule} loaded.")
 
 
 T = TypeVar("T", bound=Entity)


### PR DESCRIPTION
Forcing the `DEBUG`  log level causes everyone's logs to be filled up with unnecessary debug statements. Removing the line lets the integration inherit the system's default log level and optionally be configured for further analysis.