### PR TITLE
Add dew points for all temperature/humidity sensors

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\mikop\\\\dev\\\\homeassistant\\\\ha_comfoconnectpro\" -Filter \"*.py\" -Recurse -File)",
+      "Bash(Select-Object FullName, Length)",
+      "Bash(Sort-Object FullName)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/__init__.py)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/config_flow.py)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/const.py)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/climate.py)",
+      "mcp__ha-mcp__ha_search_entities",
+      "mcp__ha-mcp__ha_get_state",
+      "Bash(python -m ruff check custom_components/ha_comfoconnectpro/const.py custom_components/ha_comfoconnectpro/sensor.py)",
+      "Bash(ruff check *)"
+    ]
+  }
+}

--- a/custom_components/ha_comfoconnectpro/const.py
+++ b/custom_components/ha_comfoconnectpro/const.py
@@ -244,6 +244,19 @@ C_EXTRACT_HUMIDITY = "extract_humidity"
 C_EXHAUST_HUMIDITY = "exhaust_humidity"
 C_OUTDOOR_HUMIDITY = "outdoor_humidity"
 C_SUPPLY_HUMIDITY = "supply_humidity"
+
+C_ROOM_DEW_POINT = "room_dew_point"
+C_EXTRACT_DEW_POINT = "extract_dew_point"
+C_EXHAUST_DEW_POINT = "exhaust_dew_point"
+C_OUTDOOR_DEW_POINT = "outdoor_dew_point"
+C_SUPPLY_DEW_POINT = "supply_dew_point"
+
+C_ROOM_ABSOLUTE_HUMIDITY = "room_absolute_humidity"
+C_EXTRACT_ABSOLUTE_HUMIDITY = "extract_absolute_humidity"
+C_EXHAUST_ABSOLUTE_HUMIDITY = "exhaust_absolute_humidity"
+C_OUTDOOR_ABSOLUTE_HUMIDITY = "outdoor_absolute_humidity"
+C_SUPPLY_ABSOLUTE_HUMIDITY = "supply_absolute_humidity"
+
 C_CO2_SENSOR_ZONE_1 = "co2_sensor_zone_1"
 C_CO2_SENSOR_ZONE_2 = "co2_sensor_zone_2"
 C_CO2_SENSOR_ZONE_3 = "co2_sensor_zone_3"
@@ -609,6 +622,15 @@ class MySensorEntityDescription(SensorEntityDescription):
 
 
 @dataclass
+class DerivedSensorSpec:
+    """Links a synthetic sensor description to its two source hub keys."""
+
+    description: MySensorEntityDescription
+    temp_key: str
+    humidity_key: str
+
+
+@dataclass
 class MyBinaryEntityDescription(BinarySensorEntityDescription):
     """A class that describes Modbus binary entities."""
 
@@ -650,6 +672,52 @@ SELECT_TYPES: dict[str, MySelectEntityDescription] = {}
 CLIMATE_TYPES: dict[str, MyClimateEntityDescription] = {}
 NUMBER_TYPES: dict[str, MyNumberEntityDescription] = {}
 BINARY_TYPES: dict[str, MyBinaryEntityDescription] = {}
+
+_DEW_POINT_PAIRS = [
+    (C_ROOM_DEW_POINT, C_ROOM_TEMPERATURE, C_ROOM_HUMIDITY),
+    (C_EXTRACT_DEW_POINT, C_EXTRACT_TEMPERATURE, C_EXTRACT_HUMIDITY),
+    (C_EXHAUST_DEW_POINT, C_EXHAUST_TEMPERATURE, C_EXHAUST_HUMIDITY),
+    (C_OUTDOOR_DEW_POINT, C_OUTDOOR_TEMPERATURE, C_OUTDOOR_HUMIDITY),
+    (C_SUPPLY_DEW_POINT, C_SUPPLY_TEMPERATURE, C_SUPPLY_HUMIDITY),
+]
+
+DEW_POINT_SENSOR_TYPES: dict[str, DerivedSensorSpec] = {
+    key: DerivedSensorSpec(
+        description=MySensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        temp_key=temp_key,
+        humidity_key=humidity_key,
+    )
+    for key, temp_key, humidity_key in _DEW_POINT_PAIRS
+}
+
+_ABSOLUTE_HUMIDITY_PAIRS = [
+    (C_ROOM_ABSOLUTE_HUMIDITY, C_ROOM_TEMPERATURE, C_ROOM_HUMIDITY),
+    (C_EXTRACT_ABSOLUTE_HUMIDITY, C_EXTRACT_TEMPERATURE, C_EXTRACT_HUMIDITY),
+    (C_EXHAUST_ABSOLUTE_HUMIDITY, C_EXHAUST_TEMPERATURE, C_EXHAUST_HUMIDITY),
+    (C_OUTDOOR_ABSOLUTE_HUMIDITY, C_OUTDOOR_TEMPERATURE, C_OUTDOOR_HUMIDITY),
+    (C_SUPPLY_ABSOLUTE_HUMIDITY, C_SUPPLY_TEMPERATURE, C_SUPPLY_HUMIDITY),
+]
+
+ABSOLUTE_HUMIDITY_SENSOR_TYPES: dict[str, DerivedSensorSpec] = {
+    key: DerivedSensorSpec(
+        description=MySensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement="g/m³",
+            device_class=None,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        temp_key=temp_key,
+        humidity_key=humidity_key,
+    )
+    for key, temp_key, humidity_key in _ABSOLUTE_HUMIDITY_PAIRS
+}
 
 
 # --------------------------------------------------------------------

--- a/custom_components/ha_comfoconnectpro/sensor.py
+++ b/custom_components/ha_comfoconnectpro/sensor.py
@@ -1,24 +1,43 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.core import callback
 
-from .entity_common import HubBackedEntity, setup_platform_from_types
-from .const import SENSOR_TYPES, MySensorEntityDescription
+from .entity_common import HubBackedEntity, get_hub_and_device_info, setup_platform_from_types
+from .const import (
+    SENSOR_TYPES,
+    MySensorEntityDescription,
+    DerivedSensorSpec,
+    DEW_POINT_SENSOR_TYPES,
+    ABSOLUTE_HUMIDITY_SENSOR_TYPES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    return await setup_platform_from_types(
+    await setup_platform_from_types(
         hass=hass,
         entry=entry,
         async_add_entities=async_add_entities,
         types_dict=SENSOR_TYPES,
         entity_cls=MySensor,
     )
+
+    hub_name, hub, device_info = get_hub_and_device_info(hass, entry)
+    derived = [
+        DewPointSensor(hub_name, hub, device_info, spec)
+        for spec in DEW_POINT_SENSOR_TYPES.values()
+    ] + [
+        AbsoluteHumiditySensor(hub_name, hub, device_info, spec)
+        for spec in ABSOLUTE_HUMIDITY_SENSOR_TYPES.values()
+    ]
+    async_add_entities(derived)
+    return True
 
 
 class MySensor(HubBackedEntity, SensorEntity):
@@ -62,3 +81,46 @@ class MySensor(HubBackedEntity, SensorEntity):
 
         # Standard: direkt übernehmen
         self._attr_native_value = payload
+
+
+class _DerivedSensorBase(HubBackedEntity, SensorEntity):
+    """Base for sensors computed from a temperature + relative humidity pair."""
+
+    def __init__(self, platform_name: str, hub, device_info: dict, spec: DerivedSensorSpec):
+        super().__init__(platform_name, hub, device_info, spec.description)
+        self._temp_key = spec.temp_key
+        self._humidity_key = spec.humidity_key
+
+    @callback
+    def _on_hub_update(self) -> None:
+        T = self._hub.data.get(self._temp_key)
+        RH = self._hub.data.get(self._humidity_key)
+        if T is None or RH is None or not (0 < RH <= 100):
+            self._attr_native_value = None
+        else:
+            try:
+                self._attr_native_value = round(self._compute(T, RH), 1)
+            except Exception:
+                self._attr_native_value = None
+        self.async_write_ha_state()
+
+    def _compute(self, T: float, RH: float) -> float:
+        raise NotImplementedError
+
+
+class DewPointSensor(_DerivedSensorBase):
+    """Dew point via Magnus formula (August-Roche-Magnus approximation)."""
+
+    _A = 17.625
+    _B = 243.04  # °C
+
+    def _compute(self, T: float, RH: float) -> float:
+        gamma = (self._A * T) / (self._B + T) + math.log(RH / 100.0)
+        return self._B * gamma / (self._A - gamma)
+
+
+class AbsoluteHumiditySensor(_DerivedSensorBase):
+    """Absolute humidity in g/m³."""
+
+    def _compute(self, T: float, RH: float) -> float:
+        return (6.112 * math.exp((17.67 * T) / (T + 243.5)) * RH * 2.1674) / (273.15 + T)

--- a/custom_components/ha_comfoconnectpro/translations/de.json
+++ b/custom_components/ha_comfoconnectpro/translations/de.json
@@ -445,6 +445,36 @@
       },
       "filter_days_remaining": {
         "name": "Filter ersetzen in"
+      },
+      "room_dew_point": {
+        "name": "Raumluft Taupunkt"
+      },
+      "extract_dew_point": {
+        "name": "Abluft Taupunkt"
+      },
+      "exhaust_dew_point": {
+        "name": "Fortluft Taupunkt"
+      },
+      "outdoor_dew_point": {
+        "name": "Außenluft Taupunkt"
+      },
+      "supply_dew_point": {
+        "name": "Zuluft Taupunkt"
+      },
+      "room_absolute_humidity": {
+        "name": "Raumluft Absolute Feuchte"
+      },
+      "extract_absolute_humidity": {
+        "name": "Abluft Absolute Feuchte"
+      },
+      "exhaust_absolute_humidity": {
+        "name": "Fortluft Absolute Feuchte"
+      },
+      "outdoor_absolute_humidity": {
+        "name": "Außenluft Absolute Feuchte"
+      },
+      "supply_absolute_humidity": {
+        "name": "Zuluft Absolute Feuchte"
       }
     },
     "binary_sensor": {

--- a/custom_components/ha_comfoconnectpro/translations/en.json
+++ b/custom_components/ha_comfoconnectpro/translations/en.json
@@ -445,6 +445,36 @@
       },
       "filter_days_remaining": {
         "name": "Filter replacement in"
+      },
+      "room_dew_point": {
+        "name": "Room air dew point"
+      },
+      "extract_dew_point": {
+        "name": "Extract air dew point"
+      },
+      "exhaust_dew_point": {
+        "name": "Exhaust air dew point"
+      },
+      "outdoor_dew_point": {
+        "name": "Outdoor air dew point"
+      },
+      "supply_dew_point": {
+        "name": "Supply air dew point"
+      },
+      "room_absolute_humidity": {
+        "name": "Room air absolute humidity"
+      },
+      "extract_absolute_humidity": {
+        "name": "Extract air absolute humidity"
+      },
+      "exhaust_absolute_humidity": {
+        "name": "Exhaust air absolute humidity"
+      },
+      "outdoor_absolute_humidity": {
+        "name": "Outdoor air absolute humidity"
+      },
+      "supply_absolute_humidity": {
+        "name": "Supply air absolute humidity"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
This PR adds a dew point and absolute humidity sensor for each combination of a humidity and temperature sensor. This makes further automation easer as free cooling automation always wants to take extract and outdoor absolute humidities into account. Also comparing this against dew points of external room sensors or weather stations