### PR TITLE
Add dewpoint and absolute humidity sensors with Modbus fixes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(Get-ChildItem -Path \"C:\\\\Users\\\\mikop\\\\dev\\\\homeassistant\\\\ha_comfoconnectpro\" -Filter \"*.py\" -Recurse -File)",
+      "Bash(Select-Object FullName, Length)",
+      "Bash(Sort-Object FullName)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/__init__.py)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/config_flow.py)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/const.py)",
+      "Bash(python -m py_compile custom_components/ha_comfoconnectpro/climate.py)",
+      "mcp__ha-mcp__ha_search_entities",
+      "mcp__ha-mcp__ha_get_state",
+      "Bash(python -m ruff check custom_components/ha_comfoconnectpro/const.py custom_components/ha_comfoconnectpro/sensor.py)",
+      "Bash(ruff check *)"
+    ]
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,8 @@
 ## [1.0.7] - 2026-02-25 Server-Error 500 in Einstellungen gefixt
 ## [1.0.8] - 2026-02-26 Übersetzung DE/EN für Bezeichnungen und Werte ergänzt
 ## [1.0.9] - 2026-03-30 Fehlermeldung konkretisiert um Hinweis auf Modbus-Ausfall nach Umstellung Sommerzeit
+## [1.1.0] - 2026-05-06 Climate Entity hinzugefügt; Temperaturprofil 'eco' in 'cool' umbenannt
+## [1.1.1] - 2026-05-09 Externer Sollwert als Zieltemperatur in Climate Entity ergänzt
+## [1.1.2] - 2026-05-10 Taupunkt- und absolute Feuchtigkeitssensoren hinzugefügt
+## [1.1.3] - 2026-05-29 Schreibfehler in write_coil/write_register behoben (slave-Parameter und Fehlerprüfung)
 

--- a/custom_components/ha_comfoconnectpro/__init__.py
+++ b/custom_components/ha_comfoconnectpro/__init__.py
@@ -582,13 +582,13 @@ class MyModbusHub:
                     response = self._client.write_coil(
                         address=base_reg + offset,
                         value=bool(word),
-                        slave=self._hostid,
+                        device_id=self._hostid,
                     )
                 else:
                     response = self._client.write_register(
                         address=base_reg + offset,
                         value=int(word) & 0xFFFF,
-                        slave=self._hostid,
+                        device_id=self._hostid,
                     )
                 if hasattr(response, "isError") and response.isError():
                     _LOGGER.error(

--- a/custom_components/ha_comfoconnectpro/__init__.py
+++ b/custom_components/ha_comfoconnectpro/__init__.py
@@ -579,16 +579,22 @@ class MyModbusHub:
         try:
             for offset, word in enumerate(reg_values):
                 if dt == ModbusTcpClient.DATATYPE.BITS:
-                    self._client.write_coil(
+                    response = self._client.write_coil(
                         address=base_reg + offset,
                         value=bool(word),
-                        device_id=self._hostid,
+                        slave=self._hostid,
                     )
                 else:
-                    self._client.write_register(
+                    response = self._client.write_register(
                         address=base_reg + offset,
                         value=int(word) & 0xFFFF,
-                        device_id=self._hostid,
+                        slave=self._hostid,
+                    )
+                if hasattr(response, "isError") and response.isError():
+                    _LOGGER.error(
+                        "Fehler beim Schreiben von Register %s: %s",
+                        base_reg + offset,
+                        response,
                     )
         finally:
             self._client.close()

--- a/custom_components/ha_comfoconnectpro/__init__.py
+++ b/custom_components/ha_comfoconnectpro/__init__.py
@@ -187,19 +187,23 @@ class MyModbusHub:
             self._unsub_interval_method = None
             self.close()
 
+    def _do_read_cycle(self) -> bool:
+        """Connect, read all registers, close. Runs in executor under self._lock."""
+        with self._lock:
+            if not self._client.connect():
+                _LOGGER.warning("Modbus connect failed")
+                return False
+            try:
+                return self.read_modbus_registers()
+            finally:
+                self._client.close()
+
     async def async_refresh_modbus_data(self, _now: Optional[int] = None) -> None:
         """Time to update."""
         if not self._sensors:
             return
 
-        if not self._client.connect():
-            _LOGGER.warning("Modbus connect failed")
-            return
-
-        try:
-            update_result = self.read_modbus_registers()
-        finally:
-            self._client.close()
+        update_result = await self._hass.async_add_executor_job(self._do_read_cycle)
 
         if update_result:
             for update_callback in self._sensors:
@@ -436,20 +440,19 @@ class MyModbusHub:
             _LOGGER.debug(
                 f"Lese Input-Register {C_MIN_INPUT_REGISTER} bis {C_MAX_INPUT_REGISTER}..."
             )
-            with self._lock:
-                modbusdata_input = self._client.read_input_registers(
-                    address=C_MIN_INPUT_REGISTER,
-                    count=C_MAX_INPUT_REGISTER - C_MIN_INPUT_REGISTER + 1,
-                    device_id=self._hostid,
-                )
-                if not self._validate_modbus_response(
-                    modbusdata_input, "Input-Register", "registers"
-                ):
-                    return False
-                _LOGGER.debug(
-                    f"{len(modbusdata_input.registers)} Input-Register: {modbusdata_input.registers}"
-                )
-                input_regs = modbusdata_input.registers
+            modbusdata_input = self._client.read_input_registers(
+                address=C_MIN_INPUT_REGISTER,
+                count=C_MAX_INPUT_REGISTER - C_MIN_INPUT_REGISTER + 1,
+                device_id=self._hostid,
+            )
+            if not self._validate_modbus_response(
+                modbusdata_input, "Input-Register", "registers"
+            ):
+                return False
+            _LOGGER.debug(
+                f"{len(modbusdata_input.registers)} Input-Register: {modbusdata_input.registers}"
+            )
+            input_regs = modbusdata_input.registers
         else:
             _LOGGER.debug("Keine Input-Register definiert.")
             input_regs = None
@@ -458,40 +461,38 @@ class MyModbusHub:
             _LOGGER.debug(
                 f"Lese Holding-Register {C_MIN_HOLDING_REGISTER} bis {C_MAX_HOLDING_REGISTER}..."
             )
-            with self._lock:
-                modbusdata_holding = self._client.read_holding_registers(
-                    address=C_MIN_HOLDING_REGISTER,
-                    count=C_MAX_HOLDING_REGISTER - C_MIN_HOLDING_REGISTER + 1,
-                    device_id=self._hostid,
-                )
-                if not self._validate_modbus_response(
-                    modbusdata_holding, "Holding-Register", "registers"
-                ):
-                    return False
-                _LOGGER.debug(
-                    f"{len(modbusdata_holding.registers)} Holding-Register: {modbusdata_holding.registers}"
-                )
-                holding_regs = modbusdata_holding.registers
+            modbusdata_holding = self._client.read_holding_registers(
+                address=C_MIN_HOLDING_REGISTER,
+                count=C_MAX_HOLDING_REGISTER - C_MIN_HOLDING_REGISTER + 1,
+                device_id=self._hostid,
+            )
+            if not self._validate_modbus_response(
+                modbusdata_holding, "Holding-Register", "registers"
+            ):
+                return False
+            _LOGGER.debug(
+                f"{len(modbusdata_holding.registers)} Holding-Register: {modbusdata_holding.registers}"
+            )
+            holding_regs = modbusdata_holding.registers
         else:
             _LOGGER.debug("Keine Holding-Register definiert.")
             holding_regs = None
 
         if C_MAX_COILS >= C_MIN_COILS:
             _LOGGER.debug(f"Lese Coils {C_MIN_COILS} bis {C_MAX_COILS}...")
-            with self._lock:
-                modbusdata_coils = self._client.read_coils(
-                    address=C_MIN_COILS,
-                    count=C_MAX_COILS - C_MIN_COILS + 1,
-                    device_id=self._hostid,
-                )
-                if not self._validate_modbus_response(
-                    modbusdata_coils, "Coils", "bits"
-                ):
-                    return False
-                _LOGGER.debug(
-                    f"{len(modbusdata_coils.bits)} Coils: {modbusdata_coils.bits}"
-                )
-                coils = modbusdata_coils.bits
+            modbusdata_coils = self._client.read_coils(
+                address=C_MIN_COILS,
+                count=C_MAX_COILS - C_MIN_COILS + 1,
+                device_id=self._hostid,
+            )
+            if not self._validate_modbus_response(
+                modbusdata_coils, "Coils", "bits"
+            ):
+                return False
+            _LOGGER.debug(
+                f"{len(modbusdata_coils.bits)} Coils: {modbusdata_coils.bits}"
+            )
+            coils = modbusdata_coils.bits
         else:
             _LOGGER.debug("Keine Coils definiert.")
             coils = None
@@ -500,20 +501,19 @@ class MyModbusHub:
             _LOGGER.debug(
                 f"Lese Discrete Inputs {C_MIN_DISCRETE_INPUTS} bis {C_MAX_DISCRETE_INPUTS} ..."
             )
-            with self._lock:
-                modbusdata_discrete = self._client.read_discrete_inputs(
-                    address=C_MIN_DISCRETE_INPUTS,
-                    count=C_MAX_DISCRETE_INPUTS - C_MIN_DISCRETE_INPUTS + 1,
-                    device_id=self._hostid,
-                )
-                if not self._validate_modbus_response(
-                    modbusdata_discrete, "Discrete Inputs", "bits"
-                ):
-                    return False
-                _LOGGER.debug(
-                    f"{len(modbusdata_discrete.bits)} Discrete Inputs: {modbusdata_discrete.bits}"
-                )
-                discrete = modbusdata_discrete.bits
+            modbusdata_discrete = self._client.read_discrete_inputs(
+                address=C_MIN_DISCRETE_INPUTS,
+                count=C_MAX_DISCRETE_INPUTS - C_MIN_DISCRETE_INPUTS + 1,
+                device_id=self._hostid,
+            )
+            if not self._validate_modbus_response(
+                modbusdata_discrete, "Discrete Inputs", "bits"
+            ):
+                return False
+            _LOGGER.debug(
+                f"{len(modbusdata_discrete.bits)} Discrete Inputs: {modbusdata_discrete.bits}"
+            )
+            discrete = modbusdata_discrete.bits
         else:
             _LOGGER.debug("Keine Discrete Inputs definiert.")
             discrete = None
@@ -572,29 +572,30 @@ class MyModbusHub:
         """
         _LOGGER.info(f"Schreibzugriff auf Register {base_reg}: {reg_values}")
 
-        if not self._client.connect():
-            _LOGGER.warning("Modbus connect failed")
-            return
+        with self._lock:
+            if not self._client.connect():
+                _LOGGER.warning("Modbus connect failed")
+                return
 
-        try:
-            for offset, word in enumerate(reg_values):
-                if dt == ModbusTcpClient.DATATYPE.BITS:
-                    response = self._client.write_coil(
-                        address=base_reg + offset,
-                        value=bool(word),
-                        device_id=self._hostid,
-                    )
-                else:
-                    response = self._client.write_register(
-                        address=base_reg + offset,
-                        value=int(word) & 0xFFFF,
-                        device_id=self._hostid,
-                    )
-                if hasattr(response, "isError") and response.isError():
-                    _LOGGER.error(
-                        "Fehler beim Schreiben von Register %s: %s",
-                        base_reg + offset,
-                        response,
-                    )
-        finally:
-            self._client.close()
+            try:
+                for offset, word in enumerate(reg_values):
+                    if dt == ModbusTcpClient.DATATYPE.BITS:
+                        response = self._client.write_coil(
+                            address=base_reg + offset,
+                            value=bool(word),
+                            device_id=self._hostid,
+                        )
+                    else:
+                        response = self._client.write_register(
+                            address=base_reg + offset,
+                            value=int(word) & 0xFFFF,
+                            device_id=self._hostid,
+                        )
+                    if hasattr(response, "isError") and response.isError():
+                        _LOGGER.error(
+                            "Fehler beim Schreiben von Register %s: %s",
+                            base_reg + offset,
+                            response,
+                        )
+            finally:
+                self._client.close()

--- a/custom_components/ha_comfoconnectpro/const.py
+++ b/custom_components/ha_comfoconnectpro/const.py
@@ -244,6 +244,19 @@ C_EXTRACT_HUMIDITY = "extract_humidity"
 C_EXHAUST_HUMIDITY = "exhaust_humidity"
 C_OUTDOOR_HUMIDITY = "outdoor_humidity"
 C_SUPPLY_HUMIDITY = "supply_humidity"
+
+C_ROOM_DEW_POINT = "room_dew_point"
+C_EXTRACT_DEW_POINT = "extract_dew_point"
+C_EXHAUST_DEW_POINT = "exhaust_dew_point"
+C_OUTDOOR_DEW_POINT = "outdoor_dew_point"
+C_SUPPLY_DEW_POINT = "supply_dew_point"
+
+C_ROOM_ABSOLUTE_HUMIDITY = "room_absolute_humidity"
+C_EXTRACT_ABSOLUTE_HUMIDITY = "extract_absolute_humidity"
+C_EXHAUST_ABSOLUTE_HUMIDITY = "exhaust_absolute_humidity"
+C_OUTDOOR_ABSOLUTE_HUMIDITY = "outdoor_absolute_humidity"
+C_SUPPLY_ABSOLUTE_HUMIDITY = "supply_absolute_humidity"
+
 C_CO2_SENSOR_ZONE_1 = "co2_sensor_zone_1"
 C_CO2_SENSOR_ZONE_2 = "co2_sensor_zone_2"
 C_CO2_SENSOR_ZONE_3 = "co2_sensor_zone_3"
@@ -609,6 +622,15 @@ class MySensorEntityDescription(SensorEntityDescription):
 
 
 @dataclass
+class DerivedSensorSpec:
+    """Links a synthetic sensor description to its two source hub keys."""
+
+    description: MySensorEntityDescription
+    temp_key: str
+    humidity_key: str
+
+
+@dataclass
 class MyBinaryEntityDescription(BinarySensorEntityDescription):
     """A class that describes Modbus binary entities."""
 
@@ -650,6 +672,52 @@ SELECT_TYPES: dict[str, MySelectEntityDescription] = {}
 CLIMATE_TYPES: dict[str, MyClimateEntityDescription] = {}
 NUMBER_TYPES: dict[str, MyNumberEntityDescription] = {}
 BINARY_TYPES: dict[str, MyBinaryEntityDescription] = {}
+
+_DEW_POINT_PAIRS = [
+    (C_ROOM_DEW_POINT, C_ROOM_TEMPERATURE, C_ROOM_HUMIDITY),
+    (C_EXTRACT_DEW_POINT, C_EXTRACT_TEMPERATURE, C_EXTRACT_HUMIDITY),
+    (C_EXHAUST_DEW_POINT, C_EXHAUST_TEMPERATURE, C_EXHAUST_HUMIDITY),
+    (C_OUTDOOR_DEW_POINT, C_OUTDOOR_TEMPERATURE, C_OUTDOOR_HUMIDITY),
+    (C_SUPPLY_DEW_POINT, C_SUPPLY_TEMPERATURE, C_SUPPLY_HUMIDITY),
+]
+
+DEW_POINT_SENSOR_TYPES: dict[str, DerivedSensorSpec] = {
+    key: DerivedSensorSpec(
+        description=MySensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        temp_key=temp_key,
+        humidity_key=humidity_key,
+    )
+    for key, temp_key, humidity_key in _DEW_POINT_PAIRS
+}
+
+_ABSOLUTE_HUMIDITY_PAIRS = [
+    (C_ROOM_ABSOLUTE_HUMIDITY, C_ROOM_TEMPERATURE, C_ROOM_HUMIDITY),
+    (C_EXTRACT_ABSOLUTE_HUMIDITY, C_EXTRACT_TEMPERATURE, C_EXTRACT_HUMIDITY),
+    (C_EXHAUST_ABSOLUTE_HUMIDITY, C_EXHAUST_TEMPERATURE, C_EXHAUST_HUMIDITY),
+    (C_OUTDOOR_ABSOLUTE_HUMIDITY, C_OUTDOOR_TEMPERATURE, C_OUTDOOR_HUMIDITY),
+    (C_SUPPLY_ABSOLUTE_HUMIDITY, C_SUPPLY_TEMPERATURE, C_SUPPLY_HUMIDITY),
+]
+
+ABSOLUTE_HUMIDITY_SENSOR_TYPES: dict[str, DerivedSensorSpec] = {
+    key: DerivedSensorSpec(
+        description=MySensorEntityDescription(
+            key=key,
+            translation_key=key,
+            native_unit_of_measurement="g/m³",
+            device_class=None,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        temp_key=temp_key,
+        humidity_key=humidity_key,
+    )
+    for key, temp_key, humidity_key in _ABSOLUTE_HUMIDITY_PAIRS
+}
 
 
 # --------------------------------------------------------------------

--- a/custom_components/ha_comfoconnectpro/sensor.py
+++ b/custom_components/ha_comfoconnectpro/sensor.py
@@ -1,24 +1,43 @@
 from __future__ import annotations
 
 import logging
+import math
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass
+from homeassistant.core import callback
 
-from .entity_common import HubBackedEntity, setup_platform_from_types
-from .const import SENSOR_TYPES, MySensorEntityDescription
+from .entity_common import HubBackedEntity, get_hub_and_device_info, setup_platform_from_types
+from .const import (
+    SENSOR_TYPES,
+    MySensorEntityDescription,
+    DerivedSensorSpec,
+    DEW_POINT_SENSOR_TYPES,
+    ABSOLUTE_HUMIDITY_SENSOR_TYPES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    return await setup_platform_from_types(
+    await setup_platform_from_types(
         hass=hass,
         entry=entry,
         async_add_entities=async_add_entities,
         types_dict=SENSOR_TYPES,
         entity_cls=MySensor,
     )
+
+    hub_name, hub, device_info = get_hub_and_device_info(hass, entry)
+    derived = [
+        DewPointSensor(hub_name, hub, device_info, spec)
+        for spec in DEW_POINT_SENSOR_TYPES.values()
+    ] + [
+        AbsoluteHumiditySensor(hub_name, hub, device_info, spec)
+        for spec in ABSOLUTE_HUMIDITY_SENSOR_TYPES.values()
+    ]
+    async_add_entities(derived)
+    return True
 
 
 class MySensor(HubBackedEntity, SensorEntity):
@@ -62,3 +81,46 @@ class MySensor(HubBackedEntity, SensorEntity):
 
         # Standard: direkt übernehmen
         self._attr_native_value = payload
+
+
+class _DerivedSensorBase(HubBackedEntity, SensorEntity):
+    """Base for sensors computed from a temperature + relative humidity pair."""
+
+    def __init__(self, platform_name: str, hub, device_info: dict, spec: DerivedSensorSpec):
+        super().__init__(platform_name, hub, device_info, spec.description)
+        self._temp_key = spec.temp_key
+        self._humidity_key = spec.humidity_key
+
+    @callback
+    def _on_hub_update(self) -> None:
+        T = self._hub.data.get(self._temp_key)
+        RH = self._hub.data.get(self._humidity_key)
+        if T is None or RH is None or not (0 < RH <= 100):
+            self._attr_native_value = None
+        else:
+            try:
+                self._attr_native_value = round(self._compute(T, RH), 1)
+            except Exception:
+                self._attr_native_value = None
+        self.async_write_ha_state()
+
+    def _compute(self, T: float, RH: float) -> float:
+        raise NotImplementedError
+
+
+class DewPointSensor(_DerivedSensorBase):
+    """Dew point via Magnus formula (August-Roche-Magnus approximation)."""
+
+    _A = 17.625
+    _B = 243.04  # °C
+
+    def _compute(self, T: float, RH: float) -> float:
+        gamma = (self._A * T) / (self._B + T) + math.log(RH / 100.0)
+        return self._B * gamma / (self._A - gamma)
+
+
+class AbsoluteHumiditySensor(_DerivedSensorBase):
+    """Absolute humidity in g/m³."""
+
+    def _compute(self, T: float, RH: float) -> float:
+        return (6.112 * math.exp((17.67 * T) / (T + 243.5)) * RH * 2.1674) / (273.15 + T)

--- a/custom_components/ha_comfoconnectpro/translations/de.json
+++ b/custom_components/ha_comfoconnectpro/translations/de.json
@@ -445,6 +445,36 @@
       },
       "filter_days_remaining": {
         "name": "Filter ersetzen in"
+      },
+      "room_dew_point": {
+        "name": "Raumluft Taupunkt"
+      },
+      "extract_dew_point": {
+        "name": "Abluft Taupunkt"
+      },
+      "exhaust_dew_point": {
+        "name": "Fortluft Taupunkt"
+      },
+      "outdoor_dew_point": {
+        "name": "Außenluft Taupunkt"
+      },
+      "supply_dew_point": {
+        "name": "Zuluft Taupunkt"
+      },
+      "room_absolute_humidity": {
+        "name": "Raumluft Absolute Feuchte"
+      },
+      "extract_absolute_humidity": {
+        "name": "Abluft Absolute Feuchte"
+      },
+      "exhaust_absolute_humidity": {
+        "name": "Fortluft Absolute Feuchte"
+      },
+      "outdoor_absolute_humidity": {
+        "name": "Außenluft Absolute Feuchte"
+      },
+      "supply_absolute_humidity": {
+        "name": "Zuluft Absolute Feuchte"
       }
     },
     "binary_sensor": {

--- a/custom_components/ha_comfoconnectpro/translations/en.json
+++ b/custom_components/ha_comfoconnectpro/translations/en.json
@@ -445,6 +445,36 @@
       },
       "filter_days_remaining": {
         "name": "Filter replacement in"
+      },
+      "room_dew_point": {
+        "name": "Room air dew point"
+      },
+      "extract_dew_point": {
+        "name": "Extract air dew point"
+      },
+      "exhaust_dew_point": {
+        "name": "Exhaust air dew point"
+      },
+      "outdoor_dew_point": {
+        "name": "Outdoor air dew point"
+      },
+      "supply_dew_point": {
+        "name": "Supply air dew point"
+      },
+      "room_absolute_humidity": {
+        "name": "Room air absolute humidity"
+      },
+      "extract_absolute_humidity": {
+        "name": "Extract air absolute humidity"
+      },
+      "exhaust_absolute_humidity": {
+        "name": "Exhaust air absolute humidity"
+      },
+      "outdoor_absolute_humidity": {
+        "name": "Outdoor air absolute humidity"
+      },
+      "supply_absolute_humidity": {
+        "name": "Supply air absolute humidity"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
This pull request adds new synthetic sensors for dew point and absolute humidity to the Home Assistant integration, making these environmental metrics available as entities. It also refactors the Modbus read/write locking logic for improved thread safety and error handling, and updates translations to include the new sensors.

**New synthetic sensors and translations:**

* Added new synthetic sensor entities for dew point and absolute humidity for room, extract, exhaust, outdoor, and supply air, using temperature and humidity data. These are implemented via new classes (`DewPointSensor`, `AbsoluteHumiditySensor`) and supporting data structures in `sensor.py` and `const.py`.

**Modbus read/write improvements:**

* Refactored Modbus data refresh logic to ensure all register reads are performed within a locked, single connect/read/close cycle, improving reliability and thread safety. 
* Enhanced write logic to check for errors after writing coils/registers and to ensure locking during write operations.
* this fixes the problem with bad file descriptor on boost handling

**Other changes:**

* Updated the changelog to document the addition of dew point and absolute humidity sensors.